### PR TITLE
Add disable sync iptables CATTLE_NETWORK_POLICY option for vxlan-hostns

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -12,7 +12,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.7.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+    go get github.com/rancher/trash
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \

--- a/main.go
+++ b/main.go
@@ -100,6 +100,10 @@ func main() {
 			Usage: "Disable setting up CNI config and binaries",
 		},
 		cli.BoolFlag{
+			Name:  "disable-vxlanhostns-sync",
+			Usage: "Disable sync iptables CATTLE_NETWORK_POLICY chain in vxlan-hostns mode",
+		},
+		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "Turn on debug logging",
 		},
@@ -149,6 +153,7 @@ func run(c *cli.Context) error {
 		log.Errorf("Failed to start unmanaged container reaper: %v", err)
 	}
 
+	iptablessync.DisableCattleNetworkPolicySync = c.Bool("disable-vxlanhostns-sync")
 	if err := iptablessync.Watch(c.Int("iptables-sync-interval"), mClient); err != nil {
 		log.Errorf("Failed to start iptablessync: %v", err)
 	}


### PR DESCRIPTION
- Add an option for network-manager to disable the iptables sync `CATTLE_NETWORK_POLICY` chain when use `vxlan-hostns`.
- Deleted the golint install because the golang version can not be upgraded to a new version for this repo. The plugin-manager can not work if upgrade the golang version to 1.11